### PR TITLE
Force rocm dependency on hipfft with +rocm is given

### DIFF
--- a/var/spack/repos/builtin/packages/spfft/package.py
+++ b/var/spack/repos/builtin/packages/spfft/package.py
@@ -63,7 +63,7 @@ class Spfft(CMakePackage, CudaPackage, ROCmPackage):
 
     with when("+rocm"):
         depends_on("rocfft")
-        depends_on("hipfft")
+        depends_on("hipfft+rocm")
         # hip 6.0 requires v1.1.0 and later
         conflicts("^hip@6.0.0:", when="@:1.0.6 +rocm")
 


### PR DESCRIPTION
Make sure that hipfft+rocm is explicit when +rocm is true.

<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
